### PR TITLE
[FIX] FeignRequestInterceptor 类型强转失败

### DIFF
--- a/choerodon-starter-feign-replay/src/main/java/io/choerodon/feign/FeignRequestInterceptor.java
+++ b/choerodon-starter-feign-replay/src/main/java/io/choerodon/feign/FeignRequestInterceptor.java
@@ -51,7 +51,8 @@ public class FeignRequestInterceptor implements RequestInterceptor {
     @Override
     public void apply(RequestTemplate template) {
         if (SecurityContextHolder.getContext() != null
-                && SecurityContextHolder.getContext().getAuthentication() != null) {
+                && SecurityContextHolder.getContext().getAuthentication() != null
+                && SecurityContextHolder.getContext().getAuthentication().getDetails() instanceof OAuth2AuthenticationDetails) {
             OAuth2AuthenticationDetails details = (OAuth2AuthenticationDetails) SecurityContextHolder
                     .getContext().getAuthentication().getDetails();
             template.header(RequestVariableHolder.HEADER_JWT,details.getTokenType() + " " + details.getTokenValue());


### PR DESCRIPTION
在不需要授权的接口中使用Feign调用时，`io.choerodon.feign.FeignRequestInterceptor`拦截器获取到的`details`为`org.springframework.security.web.authentication.WebAuthenticationDetails`，强转`org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails`会抛出异常