### PR TITLE
Update ConvertHelper.java

### DIFF
--- a/choerodon-starter-core/src/main/java/io/choerodon/core/convertor/ConvertHelper.java
+++ b/choerodon-starter-core/src/main/java/io/choerodon/core/convertor/ConvertHelper.java
@@ -148,8 +148,16 @@ public class ConvertHelper {
 
     private static boolean isConvertorI(final Type t, final Class source, final Class destin) {
         Type rawType = ((ParameterizedType) t).getRawType();
-        if (rawType == null || !ConvertorI.class.getTypeName().equals(rawType.getTypeName())) {
+        if (rawType == null ) {
             return false;
+        }
+        if (!ConvertorI.class.getTypeName().equals(rawType.getTypeName())) {
+            Type[] superInterfaces = ((Class) rawType).genericInfo.getSuperInterfaces();
+            for (Type t : superInterfaces) {
+                if (!(t instanceof ParameterizedType && isConvertorI(t, source, destin))) {
+                    return false;
+                }
+            }
         }
         Type[] genericType2 = ((ParameterizedType) t).getActualTypeArguments();
         int num = 0;


### PR DESCRIPTION
我通过继承`ConvertorI`接口,编写了一个自动转换对象的`AutoConverter`接口
该接口中含有默认的自动转换代码方法
但是在调用`ConverterHelper.convert()`时总是出现错误
通过DEBUUG发现是`isConvertorI()`中的判断条件不通过导致无法转换对象
希望能够加入判断条件,允许扩展`ConvertorI`接口