### PR TITLE
[IMP]update mysql jdbc version for mysql 8.0+

### DIFF
--- a/choerodon-tool-liquibase/pom.xml
+++ b/choerodon-tool-liquibase/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xmlns="http://maven.apache.org/POM/4.0.0" 
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>choerodon-starter-parent</artifactId>
@@ -30,6 +30,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.14</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
@@ -53,9 +54,8 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
         </dependency>
-
     </dependencies>
-
+    
     <build>
         <resources>
             <resource>


### PR DESCRIPTION
An exception occurs when using default mysql jdbc version to connect with mysql 8.0.13, the core exception message is :

java.sql.SQLException: Unknown system variable 'query_cache_size'

and there is the solution: [stackoverflow](https://stackoverflow.com/questions/49984267/java-sql-sqlexception-unknown-system-variable-query-cache-size)

