### PR TITLE
[UPD] SagaTask 返回值无法生成demo数据时,使用类名作为output_schema样例数据以提升可读性

### DIFF
--- a/choerodon-starter-asgard/src/main/java/io/choerodon/asgard/saga/consumer/GenerateJsonSchemaUtil.java
+++ b/choerodon-starter-asgard/src/main/java/io/choerodon/asgard/saga/consumer/GenerateJsonSchemaUtil.java
@@ -14,6 +14,14 @@ public class GenerateJsonSchemaUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GenerateJsonSchemaUtil.class);
 
+    /**
+     * Primitive types's box class and usual return types.
+     * Refer to {@link Class#isPrimitive()}
+     */
+    private static final List<Class> USUAL_RETURN_TYPES = Arrays.asList(String.class, Boolean.class, Character.class,
+            Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class,
+            Void.class, Map.class, Enum.class);
+
     private GenerateJsonSchemaUtil() {
     }
 
@@ -30,9 +38,12 @@ public class GenerateJsonSchemaUtil {
         return value;
     }
 
-    static Object createExampleInstance(final Class<?> claz) {
+    private static Object createExampleInstance(final Class<?> claz) {
         if (claz == null) {
             return null;
+        }
+        if (claz.isPrimitive() || USUAL_RETURN_TYPES.contains(claz)) {
+            return claz.getSimpleName();
         }
         if (claz.isArray() || Collection.class.isAssignableFrom(claz)) {
             return Collections.emptyList();

--- a/choerodon-starter-asgard/src/test/java/io/choerodon/asgard/preoperty/saga/GenerateJsonSchemaUtilTest.java
+++ b/choerodon-starter-asgard/src/test/java/io/choerodon/asgard/preoperty/saga/GenerateJsonSchemaUtilTest.java
@@ -1,0 +1,62 @@
+package io.choerodon.asgard.preoperty.saga;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.choerodon.asgard.saga.consumer.GenerateJsonSchemaUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GenerateJsonSchemaUtilTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    public void generate() {
+        Map<String, String> expectedResult = new HashMap<>();
+        expectedResult.put("aInteger", "\"Integer\"");
+        expectedResult.put("anInt", "\"int\"");
+        expectedResult.put("aBoolean", "\"boolean\"");
+        expectedResult.put("aString", "\"String\"");
+        expectedResult.put("aVoid", "\"void\"");
+        expectedResult.put("aMap", "\"Map\"");
+        expectedResult.put("anEnum", "\"Enum\"");
+
+        Arrays.asList(Demo.class.getDeclaredMethods()).forEach(method -> {
+            String outputSchemaDemo = GenerateJsonSchemaUtil.generate(method.getReturnType(), OBJECT_MAPPER, false);
+            Assert.assertEquals(outputSchemaDemo, expectedResult.get(method.getName()));
+        });
+    }
+
+    private class Demo {
+        public int anInt() {
+            return 0;
+        }
+
+        public Integer aInteger() {
+            return 0;
+        }
+
+        public boolean aBoolean() {
+            return false;
+        }
+
+        public String aString() {
+            return "";
+        }
+
+        public void aVoid() {
+        }
+
+        public Map aMap() {
+            return null;
+        }
+
+        public Enum anEnum() {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
asgard_orch_saga_task.output_schema 中生成的样例数据存在大量: null、""，无法直观体现 SagaTask 的返回值。同时，当返回值为基础类型或其他常见类型时，以反射方式创建类实例并初始化属性会报异常并打印TRACE日志。